### PR TITLE
Fix create contest date time bug

### DIFF
--- a/src/main/generator/pages/contests.py
+++ b/src/main/generator/pages/contests.py
@@ -40,6 +40,7 @@ def editContest(params, user):
     existingProblems = []
     start = time.time() * 1000
     end = (time.time() + 3600) * 1000
+    scoreboardOff = (time.time() + 3600) * 1000
     if contest:
         title = contest.name
         start = contest.start

--- a/src/main/serve/scripts/script.js
+++ b/src/main/serve/scripts/script.js
@@ -417,12 +417,17 @@ Contest page
         var scoreboardOffTime = $("#scoreboard-off-time").val();
 
 
-        // Invalid DATE format; Insert "T" after the date and "Z" after the time for the correct format
-        // for creating the Dates
+        // Invalid DATE format; "T" after the date and "Z" after the time have been inserted 
+        // for the correct format for creating the Dates, then the milliseconds are adjusted 
+        // for the correct time zone for each of the following variables, since "Z" assumes you
+        // are entering a UTC time.
 
-        var start = new Date(`${startDate}T${startTime}Z`).getTime();
-        var end = new Date(`${endDate}T${endTime}Z`).getTime();
-        var endScoreboard = new Date(`${endDate}T${scoreboardOffTime}Z`).getTime();
+        var start = new Date(`${startDate}T${startTime}Z`);
+        start = start.getTime() + (start.getTimezoneOffset() * 60000);
+        var end = new Date(`${endDate}T${endTime}Z`);
+        end = end.getTime() + (end.getTimezoneOffset() * 60000);
+        var endScoreboard = new Date(`${endDate}T${scoreboardOffTime}Z`);
+        endScoreboard = endScoreboard.getTime() + (endScoreboard.getTimezoneOffset() * 60000);
 
         if (end <= start) {
             alert("The end of the contest must be after the start.");

--- a/src/main/serve/scripts/script.js
+++ b/src/main/serve/scripts/script.js
@@ -416,9 +416,13 @@ Contest page
         var endTime = $("#contest-end-time").val();
         var scoreboardOffTime = $("#scoreboard-off-time").val();
 
-        var start = new Date(`${startDate} ${startTime}`).getTime();
-        var end = new Date(`${endDate} ${endTime}`).getTime();
-        var endScoreboard = new Date(`${endDate} ${scoreboardOffTime}`).getTime();
+
+        // Invalid DATE format; Insert "T" after the date and "Z" after the time for the correct format
+        // for creating the Dates
+
+        var start = new Date(`${startDate}T${startTime}Z`).getTime();
+        var end = new Date(`${endDate}T${endTime}Z`).getTime();
+        var endScoreboard = new Date(`${endDate}T${scoreboardOffTime}Z`).getTime();
 
         if (end <= start) {
             alert("The end of the contest must be after the start.");


### PR DESCRIPTION
The time format for the dates was changing the times to UTC, pushing the inputted times back four hours. I adjusted the code to automatically change the milliseconds amount after creating the dates for the contest so that they always equal the correct time zone. The contest creation feature should work correctly now.