### PR TITLE
Admin Edit Test Cases

### DIFF
--- a/opencontest/contest/pages/lib/page.py
+++ b/opencontest/contest/pages/lib/page.py
@@ -97,7 +97,7 @@ class Page(UIElement):
 
 
 class Card(UIElement):
-    def __init__(self, title, contents, link=None, cls=None, delete=None, reply=None, rejudge=None):
+    def __init__(self, title, contents, link=None, cls=None, delete=None, reply=None, rejudge=None, edit=None):
         if cls == None:
             cls = "card"
         else:
@@ -110,10 +110,16 @@ class Card(UIElement):
         if rejudge:
             deleteLink = div(h.button("Rejudge All", cls="btn btn-primary", onclick=rejudge), cls="delete-link")
 
+                # Add a pencil to the card if one is desired
+        editLink = ""
+        if edit:
+            editLink = div(h.i("edit", cls="material-icons", onclick=edit), cls="delete-link")
+        
         self.html = h.div(cls=cls, contents=[
             div(cls="card-header", contents=[
                 h2(contents=[title], cls="card-title"),
-                deleteLink
+                deleteLink,
+                editLink
             ]),
             div(cls="card-contents", contents=contents)
         ])
@@ -122,9 +128,13 @@ class Card(UIElement):
 
 
 class Modal(UIElement):
-    def __init__(self, title, body, footer):
+    def __init__(self, title, body, footer, modalID=""):
+        '''
+        modalID - used to uniquely identify different modals. Only necessary when
+                  two or more modals are present on page
+        '''
         # taken from https://getbootstrap.com/docs/4.1/components/modal/
-        self.html = div(cls="modal", role="dialog", contents=[
+        self.html = div(cls=f"modal {modalID}", role="dialog", contents=[
             div(cls="modal-dialog", role="document", contents=[
                 div(cls="modal-content", contents=[
                     div(cls="modal-header", contents=[

--- a/opencontest/contest/pages/problemEdit.py
+++ b/opencontest/contest/pages/problemEdit.py
@@ -44,7 +44,7 @@ class TestDataCard(UIElement):
                 p("Output:", cls="no-margin"),
                 h.code(code_encode(testData.output))
             ])
-        ]), cls=cls, delete=f"deleteTestData({num})")
+        ]), cls=cls, delete=f"deleteTestDataDialog({num})", edit=f"editTestDataDialog({num})")
 
 
 @admin_required
@@ -109,7 +109,35 @@ def editProblem(request, *args, **kwargs):
             div(
                 h.button("Cancel", **{"type":"button", "class": "button button-white", "data-dismiss": "modal"}),
                 h.button("Add Test Data", **{"type":"button", "class": "button", "onclick": "createTestData()"})
-            )
+            ),
+            modalID="create-test-data"
+        ),
+        Modal(
+            "Edit Test Data",
+            div(
+                h.h5("Input"),
+                h.textarea(rows="5", cls="edit-test-input col-12 monospace margin-bottom"),
+                h.h5("Output"),
+                h.textarea(rows="5", cls="edit-test-output col-12 monospace"),
+                h.p("ID", cls="current-test-data-id", hidden="")
+            ),
+            div(
+                h.button("Cancel", **{"type":"button", "class": "button button-white", "data-dismiss": "modal"}),
+                h.button("Save Changes", **{"type":"button", "class": "button", "onclick": "editTestData()"})
+            ),
+            modalID="edit-test-data"
+        ),
+        Modal(
+            "Delete Confirmation",
+            div(
+                h.h2("Are you sure that you want to delete test case?", cls="delete-test-data-question"),
+                h.p("ID", cls="delete-test-data-id", hidden="")
+            ),
+            div(
+                h.button("No", **{"type":"button", "class": "button button-white", "data-dismiss": "modal"}),
+                h.button("Yes", **{"type":"button", "class": "button", "onclick": "deleteTestData()"})
+            ),
+            modalID="delete-test-data"
         ),
         div(cls="test-data-cards", contents=list(map(TestDataCard, zip(range(prob.tests), prob.testData, [prob.samples] * prob.tests))))
     ))

--- a/opencontest/contest/static/scripts/script.js
+++ b/opencontest/contest/static/scripts/script.js
@@ -588,7 +588,7 @@ Problems page
 Problem page
 --------------------------------------------------------------------------------------------------*/
     function createTestDataDialog() {
-        $("div.modal").modal();
+        $(".create-test-data").modal();
     }
 
     function createTestData() {
@@ -644,12 +644,71 @@ Problem page
         return false;
     }
 
-    function deleteTestData(dataNum) {
+    /**
+     * Opens and Initializes a dialog box confirming if the admin wants to delete a test cases
+     * @param   {Number} dataNum    Test case number to delete
+     */
+    function deleteTestDataDialog(dataNum) {
+
+        // Change the question to ask about the relevant Test Case number
+        $(".delete-test-data-question").html(`Are you sure you want to delete Test Case #${dataNum}?`);
+
+        // Set the test data id variable appropriately
+        $(".delete-test-data-id").html(dataNum);
+
+        // Open the modal
+        $(".delete-test-data").modal();
+    }
+
+    function deleteTestData() {
         if ($(".test-data-cards .card").length <= $("#problem-samples").val()) {
             alert("Deleting this item would make the number of sample cases invalid.");
             return;
         }
+        let dataNum = $(".delete-test-data-id").html();
         $(`.test-data-cards .card:eq(${dataNum})`).remove();
+        editProblem();
+    }
+    
+        /**
+     * Opens and Initializes a dialog box for editing test cases
+     * @param   {Number} dataNum    Test case number to edit
+     */
+    function editTestDataDialog(dataNum) {
+
+        // Get test case data from test case cards
+        let input = $(`.test-data-cards .card:eq(${dataNum}) code:eq(0)`).html();
+        let output = $(`.test-data-cards .card:eq(${dataNum}) code:eq(1)`).html();
+
+        // Load data into dialog
+        $(".edit-test-input").val(input);
+        $(".edit-test-output").val(output);
+
+        // Change the title of the card to match case number
+        $(".edit-test-data .modal-title").html(`Editing Test Case #${dataNum}`);
+        $(".current-test-data-id").html(dataNum);
+
+        // Load the 
+        $(`.edit-test-data`).modal();
+    }
+
+    /**
+     * Saves test cases currently in the editor
+     */
+    function editTestData() {
+
+        // Get the test case id
+        dataNum = $(".current-test-data-id").html();
+
+        // Get the new input and output
+        let input = $(".edit-test-input").val();
+        let output = $(".edit-test-output").val();
+
+        // Load the new input and output into the test case cards
+        $(`.test-data-cards .card:eq(${dataNum}) code:eq(0)`).html(input);
+        $(`.test-data-cards .card:eq(${dataNum}) code:eq(1)`).html(output);
+
+        // Upload data to server
         editProblem();
     }
     

--- a/opencontest/contest/static/scripts/script.js
+++ b/opencontest/contest/static/scripts/script.js
@@ -677,8 +677,8 @@ Problem page
     function editTestDataDialog(dataNum) {
 
         // Get test case data from test case cards
-        let input = $(`.test-data-cards .card:eq(${dataNum}) code:eq(0)`).html();
-        let output = $(`.test-data-cards .card:eq(${dataNum}) code:eq(1)`).html();
+        let input = $(`.test-data-cards .card:eq(${dataNum}) code:eq(0)`).text();
+        let output = $(`.test-data-cards .card:eq(${dataNum}) code:eq(1)`).text();
 
         // Load data into dialog
         $(".edit-test-input").val(input);
@@ -705,8 +705,8 @@ Problem page
         let output = $(".edit-test-output").val();
 
         // Load the new input and output into the test case cards
-        $(`.test-data-cards .card:eq(${dataNum}) code:eq(0)`).html(input);
-        $(`.test-data-cards .card:eq(${dataNum}) code:eq(1)`).html(output);
+        $(`.test-data-cards .card:eq(${dataNum}) code:eq(0)`).text(input);
+        $(`.test-data-cards .card:eq(${dataNum}) code:eq(1)`).text(output);
 
         // Upload data to server
         editProblem();


### PR DESCRIPTION
Adds a pencil icon so that admins can edit test data in the browser while the contest is running. Also adds a confirmation dialog before a test case is deleted.